### PR TITLE
fix: the python code embedded in tools/render-og in render-og.sh

### DIFF
--- a/tools/render-og.sh
+++ b/tools/render-og.sh
@@ -59,9 +59,13 @@ render() { # <format> <width> <height> <outfile>
   [ -s "$tmp/$f.png" ] || { echo "browser wrote no screenshot for $f" >&2; exit 1; }
   local size
   size="$(python3 -c "
-import struct, sys
-print('%dx%d' % struct.unpack('>II', open(sys.argv[1],'rb').read(24)[16:24]))
-" "$tmp/$f.png")"
+import os, struct, sys
+path = os.path.realpath(sys.argv[1])
+sandbox = os.path.realpath(sys.argv[2]) + os.sep
+if not path.startswith(sandbox):
+    sys.exit('refusing to read outside sandbox: ' + path)
+print('%dx%d' % struct.unpack('>II', open(path,'rb').read(24)[16:24]))
+" "$tmp/$f.png" "$tmp")"
   [ "$size" = "${w}x${h}" ] || { echo "$f: expected ${w}x${h}, got $size" >&2; exit 1; }
 
   mv "$tmp/$f.png" "$out"


### PR DESCRIPTION
## Summary
Fix high severity security issue in `tools/render-og.sh`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `tools/render-og.sh:63` |
| **Assessment** | Likely exploitable |

**Description**: The Python code embedded in tools/render-og.sh reads from a file path specified via sys.argv[1] without any path validation, sanitization, or canonicalization. An attacker who can control the command line argument can read the first 24 bytes of any file accessible to the process, including sensitive system files.

## Evidence

**Exploitation scenario**: Invoke the render-og.sh script with a controlled argument pointing to a sensitive file.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Changes
- `tools/render-og.sh`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
