### PR TITLE
Wait for the playlist before asserting about it

### DIFF
--- a/tools/test-browser.mjs
+++ b/tools/test-browser.mjs
@@ -647,9 +647,17 @@ async function autoplayAllowed({ songs, eps }) {
     const wanted = songs[1];
     const song = wanted.path;
     await tab.go(song);
-    let s = await until('the song to start', async () => {
+    /* Playing *and* holding the whole playlist. Two things that arrive on
+       their own schedules — the seeded row plays on the first tick, the
+       manifest lands a moment later — and this section asserts about both,
+       so it has to wait for both. Against a local server the second is
+       instant and the race is never lost; over the wire the list turns up
+       around 140ms in and the poll is every 100, which is close enough to
+       lose it about half the time. That is the fourth time this file has
+       waited for one thing and asserted about another. */
+    let s = await until('the song to start, out of the whole playlist', async () => {
       const st = await tab.state();
-      return st.playing && st.at > 0 ? st : null;
+      return st.playing && st.at > 0 && st.rows >= songs.length ? st : null;
     });
     if (s) {
       is(s.path, song, 'the address stays put');


### PR DESCRIPTION
`SITE=https://radio.omarchy.org node tools/test-browser.mjs` failed against the freshly deployed site where it passes against a local one:

```
FAIL  the whole playlist arrived (1 rows)
```

**The site was fine** — 33 rows, `playing`, no console errors, and every route serving. The test was not.

It waits for playback and then asserts about the list, and those arrive on their own schedules: the row baked into a permalink plays on the first tick, the manifest lands a moment later. Measured over the wire, the full list turns up around **140ms** in; the poll is every 100ms. Close enough to lose about half the time. Against a local server the manifest is instant, so it never loses and the race was invisible.

This is the **fourth** time this file has waited for one thing and asserted about another — the offline leg read the prerendered row and called the cache empty, the find section typed before the deck had booted, the theme section read the menu before it was built. Same fix each time: wait for both.

129 checks, against localhost and against the deployed site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)