### PR TITLE
Add shuffle playback controls

### DIFF
--- a/src/components/Transport.astro
+++ b/src/components/Transport.astro
@@ -13,6 +13,7 @@ import Icon from './Icon.astro';
     <button type="button" class="tb tb-play" id="toggle" aria-label="Play or pause"><Icon name="play" /><Icon name="pause" /></button>
     <button type="button" class="tb" id="stop" aria-label="Stop"><Icon name="stop" /></button>
     <button type="button" class="tb" id="next" aria-label="Next track"><Icon name="next" /></button>
+    <button type="button" class="tb tb-shuffle" id="shuffle" aria-label="Shuffle" aria-pressed="false">SHUF</button>
   </div>
 
   <div class="seek" id="seek" role="slider" tabindex="0" aria-label="Seek" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">

--- a/src/scripts/deck.ts
+++ b/src/scripts/deck.ts
@@ -57,7 +57,7 @@ var IDS = [
   'bg', 'fit', 'app', 'lcd', 'lcdSrc', 'lcdBody', 'lcdOut',
   'themeBtn', 'themeMenu',
   'themeCaret', 'skinName', 'stationLabel', 'srcLabel',
-  'marq', 'artist', 'curTime', 'durTime', 'vis', 'prev', 'toggle', 'stop', 'next',
+  'marq', 'artist', 'curTime', 'durTime', 'vis', 'prev', 'toggle', 'stop', 'next', 'shuffle',
   'seek', 'seekFill', 'seekHead', 'volKnob', 'volRot', 'volLabel',
   'playlistKind', 'playlistName', 'tracks', 'trHead', 'playlistNote',
   'status', 'seg', 'tabSongs', 'tabPodcast',
@@ -103,6 +103,7 @@ interface State {
   vol: number;
   cur: number;
   dur: number;
+  shuffle: boolean;
   /** The name of the theme on, which is what survives the list changing
       under it: the desktop's own theme appears at the top of the list the
       moment the extension offers one, and an index would then mean the
@@ -130,6 +131,7 @@ var S: State = {
   vol: 0.8,
   cur: 0,
   dur: 0,
+  shuffle: false,
   skin: SKINS[0]!.name,
   themeOpen: false,
   lyricsOpen: false,
@@ -231,6 +233,12 @@ var el = {} as Els;
 // so in the list without rebuilding it: the list is also what the listener
 // is reading, and a rebuild throws away their scroll position.
 var stateCell: HTMLElement | null = null;
+/* A shuffle is a listening run, not a permanently reordered playlist. The
+   current song begins it; `remaining` holds each other track once, while
+   `history` lets Previous mean the song the listener actually just heard. */
+var shuffleHistory: number[] = [];
+var shuffleAt = -1;
+var shuffleRemaining: number[] = [];
 /** The row that cell sits in, for the one thing that wants the whole row. */
 var playingRow: HTMLElement | null = null;
 /** And which item that row is, which is not always the one being looked for. */
@@ -839,12 +847,65 @@ function playFrom(list: Item[], mode: Mode, i: number, how?: How) {
   syncRoute(how);
 }
 
+function shuffled(indices: number[]): number[] {
+  for (var i = indices.length - 1; i > 0; i--) {
+    var j = Math.floor(Math.random() * (i + 1));
+    var swap = indices[i]!;
+    indices[i] = indices[j]!;
+    indices[j] = swap;
+  }
+  return indices;
+}
+
+function beginShuffle(i: number) {
+  shuffleHistory = i >= 0 ? [i] : [];
+  shuffleAt = shuffleHistory.length - 1;
+  shuffleRemaining = shuffled(S.tracks.map(function (_, n) { return n; }).filter(function (n) {
+    return n !== i;
+  }));
+}
+
+function shuffleNext(): boolean {
+  if (!S.tracks.length) return false;
+  // Returning from Previous follows the run the listener has already made.
+  if (shuffleAt < shuffleHistory.length - 1) {
+    shuffleAt++;
+    playFrom(S.tracks, 'track', shuffleHistory[shuffleAt]!);
+    return true;
+  }
+  // One cycle visits every other song before it starts afresh. Leave the
+  // current song out of the new bag so the seam can never repeat it.
+  if (!shuffleRemaining.length) {
+    shuffleRemaining = shuffled(S.tracks.map(function (_, n) { return n; }).filter(function (n) {
+      return n !== S.ti;
+    }));
+  }
+  var i = shuffleRemaining.pop();
+  if (i === undefined) return false; // a one-track playlist stays put
+  shuffleHistory.push(i);
+  shuffleAt = shuffleHistory.length - 1;
+  playFrom(S.tracks, 'track', i);
+  return true;
+}
+
+function toggleShuffle() {
+  S.shuffle = !S.shuffle;
+  if (S.shuffle) beginShuffle(S.mode === 'track' ? S.ti : -1);
+  else {
+    shuffleHistory = [];
+    shuffleAt = -1;
+    shuffleRemaining = [];
+  }
+  paintTransport();
+}
+
 // The two ways in that mean the listener named this one: a row, or a link.
 // Stepping with the transport goes through playFrom() and leaves that be.
 function playTrack(i: number, how?: How) {
   chose = true;
   S.tab = 'songs';
   S.route = 'playlist';
+  if (S.shuffle) beginShuffle(i);
   playFrom(S.tracks, 'track', i, how);
 }
 
@@ -892,11 +953,18 @@ function stop() {
 // the first one. Transport rather than navigation, so they leave the
 // history and — unless the listener had named a song — the address alone.
 function next() {
+  if (S.shuffle && S.mode === 'track' && shuffleNext()) return;
   var l = playingList();
   if (l && l.length) playFrom(l, S.mode, (S.ti + 1) % l.length);
 }
 
 function prev() {
+  if (S.shuffle && S.mode === 'track') {
+    if (shuffleAt <= 0) return;
+    shuffleAt--;
+    playFrom(S.tracks, 'track', shuffleHistory[shuffleAt]!);
+    return;
+  }
   var l = playingList();
   if (l && l.length) playFrom(l, S.mode, (S.ti - 1 + l.length) % l.length);
 }
@@ -1404,6 +1472,9 @@ function paintTransport() {
      say the same two things. */
   el.toggle.classList.toggle('is-playing', S.playing);
   el.toggle.setAttribute('aria-label', S.playing ? 'Pause' : 'Play');
+  el.shuffle.hidden = S.mode === 'story';
+  el.shuffle.classList.toggle('is-on', S.shuffle);
+  el.shuffle.setAttribute('aria-pressed', String(S.shuffle));
   el.volRot.style.transform = 'rotate(' + (-135 + S.vol * 270) + 'deg)';
   el.volLabel.textContent = String(Math.round(S.vol * 100));
   el.volKnob.setAttribute('aria-valuenow', String(Math.round(S.vol * 100)));
@@ -2287,6 +2358,7 @@ function boot() {
   el.stop.addEventListener('click', stop);
   el.next.addEventListener('click', next);
   el.prev.addEventListener('click', prev);
+  el.shuffle.addEventListener('click', toggleShuffle);
   el.lyricsBtn.addEventListener('click', toggleLyrics);
 
   el.find.addEventListener('input', function () {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -512,6 +512,7 @@ a, button, [role="slider"] { -webkit-tap-highlight-color: transparent; }
 }
 .tb:first-child { margin-left: 0; }
 .tb:hover { border-color: var(--ac); color: var(--ac); z-index: 1; }
+.tb[hidden] { display: none; }
 
 .tb-play {
   width: 74px;
@@ -521,6 +522,8 @@ a, button, [role="slider"] { -webkit-tap-highlight-color: transparent; }
   border-color: var(--ac);
 }
 .tb-play:hover { background: var(--acHi); border-color: var(--acHi); color: var(--acFg); }
+.tb-shuffle { width: 52px; font-size: 9px; letter-spacing: .12em; }
+.tb-shuffle.is-on { color: var(--ac); border-color: var(--ac); z-index: 1; }
 
 .seek {
   flex: 1;

--- a/tools/test-browser.mjs
+++ b/tools/test-browser.mjs
@@ -164,6 +164,15 @@ window.__state = function () {
       function (li) { return li.dataset.skin; }),
     tab: (document.querySelector('.seg-b.is-on') || {}).id || '',
     note: (document.getElementById('playlistNote') || {}).textContent || '',
+    shuffle: (function () {
+      var button = document.getElementById('shuffle');
+      return button && button.getAttribute ? button.getAttribute('aria-pressed') || '' : '';
+    })(),
+    shuffleVisible: (function () {
+      var button = document.getElementById('shuffle');
+      return !!(button && !button.hidden &&
+        (!window.getComputedStyle || window.getComputedStyle(button).display !== 'none'));
+    })(),
     plays: window.__probe.plays.slice(),
     statuses: window.__probe.statuses.slice(),
     copied: window.__probe.copied.slice(),
@@ -908,6 +917,105 @@ async function autoplayAllowed({ songs, eps }) {
   }
 }
 
+async function shuffle({ songs, eps }) {
+  section('shuffling the music without losing the listening run');
+  const browser = await Browser.launch('no-user-gesture-required');
+  const tab = await browser.tab();
+  try {
+    await tab.go(songs[0].path);
+    let s = await until('the playlist to settle before shuffling', async () => {
+      const st = await tab.state();
+      return st.playing && st.rows >= songs.length ? st : null;
+    });
+    if (!s) return;
+
+    const start = s.row;
+    const address = s.path;
+    await tab.click('#shuffle');
+    s = await until('shuffle to turn on', async () => {
+      const st = await tab.state();
+      return st.shuffle === 'true' ? st : null;
+    });
+    if (!s) return;
+    is(s.row, start, 'turning shuffle on leaves the current song alone');
+    is(s.path, address, 'and does not change the address');
+    is(s.shuffleVisible, true, 'the shuffle control is visible for songs');
+
+    const step = async (what) => {
+      const from = (await tab.state()).row;
+      await tab.click('#next');
+      return until(what, async () => {
+        const st = await tab.state();
+        return st.row && st.row !== from ? st : null;
+      });
+    };
+
+    const first = await step('the first shuffled song');
+    if (!first) return;
+    const second = await step('the second shuffled song');
+    if (!second) return;
+    await tab.click('#prev');
+    s = await until('the previous shuffled song', async () => {
+      const st = await tab.state();
+      return st.row === first.row ? st : null;
+    });
+    if (!s) return;
+    s = await step('the forward shuffled song after going back');
+    if (!s) return;
+    is(s.row, second.row, 'next resumes the shuffled listening history');
+
+    await tab.eval(`(function () {
+      var live = window.__probe.media.filter(function (m) { return !m.paused; })[0];
+      if (live) live.dispatchEvent(new Event('ended'));
+    })()`);
+    s = await until('the song after a shuffled track ends', async () => {
+      const st = await tab.state();
+      return st.row && st.row !== second.row ? st : null;
+    });
+    if (!s) return;
+
+    const heard = new Set([start, first.row, second.row, s.row]);
+    while (heard.size < songs.length) {
+      s = await step('another unplayed shuffled song');
+      if (!s) return;
+      ok(!heard.has(s.row), `shuffle does not repeat ${s.row} before its cycle ends`);
+      heard.add(s.row);
+    }
+    is(heard.size, songs.length, 'one shuffled cycle hears every song once');
+
+    const last = s.row;
+    s = await step('the first song in the next shuffled cycle');
+    if (!s) return;
+    ok(s.row !== last, 'the seam between shuffle cycles does not repeat the current song');
+
+    await tab.click('#shuffle');
+    s = await until('shuffle to turn off', async () => {
+      const st = await tab.state();
+      return st.shuffle === 'false' ? st : null;
+    });
+    if (!s) return;
+    const at = songs.findIndex((song) => song.title === s.row);
+    await tab.click('#next');
+    s = await until('the sequential song after shuffle', async () => {
+      const st = await tab.state();
+      return st.row === songs[(at + 1) % songs.length].title ? st : null;
+    });
+    if (s) is(s.shuffle, 'false', 'turning shuffle off restores sequential playback');
+
+    if (eps.length) {
+      await tab.go(eps[0].path);
+      s = await until('the podcast episode to play', async () => {
+        const st = await tab.state();
+        return st.playing && st.tab === 'tabPodcast' ? st : null;
+      });
+      if (s) is(s.shuffleVisible, false, 'podcast playback does not offer shuffle');
+    }
+  } finally {
+    await tab.close();
+    await browser.close();
+  }
+}
+
 async function autoplayRefused({ songs }) {
   section('with autoplay refused, the way a browser treats a first visit');
   const browser = await Browser.launch('user-gesture-required');
@@ -1026,6 +1134,7 @@ try {
   const site = await routes();
   console.log(`${site.songs.length} songs, ${site.eps.length} episodes`);
   await autoplayAllowed(site);
+  await shuffle(site);
   await autoplayRefused(site);
   await find(site);
   await reveal(site);


### PR DESCRIPTION
The radio only advanced through the playlist sequentially, so listeners could not explore the community mix in a random order. Add a song-only SHUF toggle that plays each track once per cycle, remembers Previous/Next listening history, and keeps podcast playback ordered. Cover the toggle, shuffled cycle, automatic advancement, sequential fallback, and podcast exclusion in browser tests.